### PR TITLE
fix(inv): Change versicherten_status to ljust

### DIFF
--- a/lib/ruby_gkv_billing/edifact/message/slla/inv.rb
+++ b/lib/ruby_gkv_billing/edifact/message/slla/inv.rb
@@ -34,7 +34,7 @@ module RubyGkvBilling
           )
             #INV_SEGMENT
             @versicherten_nummer = versicherten_nummer
-            @versicherten_status = versicherten_status.to_s.rjust(5, "0")[0..4]
+            @versicherten_status = versicherten_status.to_s.ljust(5, "0")[0..4]
             @beleg_info = beleg_info
             @beleg_nummer = beleg_nummer
             @besondere_versorgungsform = besondere_versorgungsform

--- a/spec/unit/edifact/message/slla/inv_spec.rb
+++ b/spec/unit/edifact/message/slla/inv_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe RubyGkvBilling::Edifact::Message::Slla::Inv do
     "merkmal"
     ) }
 
-  it { expect(subject.inv_segment.to_edifact).to eq("INV+versicherten_nr+00018+0+beleg_nr+besondere_versorgung'") }
+  it { expect(subject.inv_segment.to_edifact).to eq("INV+versicherten_nr+18000+0+beleg_nr+besondere_versorgung'") }
 
   it { expect(subject.uri_segment.to_edifact).to eq("URI+123456789+sammel:einzel+20101010+belegnum'") }
 

--- a/spec/unit/edifact/message/slla/medicine_spec.rb
+++ b/spec/unit/edifact/message/slla/medicine_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe RubyGkvBilling::Edifact::Message::Slla::Medicine do
 
   it { expect(subject.gzf_segment.to_edifact).to eq("GZF+567,43+43,00+765,46'") }
 
-  it { expect(subject.inv_segment.to_edifact).to eq("INV+versicherten_nr+00018+0+beleg_nr+besondere_versorgung'") }
+  it { expect(subject.inv_segment.to_edifact).to eq("INV+versicherten_nr+18000+0+beleg_nr+besondere_versorgung'") }
 
   it { expect(subject.uri_segment.to_edifact).to eq("URI+123456789+sammel:einzel+20200101+belegnum'") }
 
@@ -109,7 +109,7 @@ RSpec.describe RubyGkvBilling::Edifact::Message::Slla::Medicine do
   it { expect(subject.segments.count).to eq(11) }
 
   describe "in sequence" do
-    it { expect(subject.segments[0].to_edifact).to eq("INV+versicherten_nr+00018+0+beleg_nr+besondere_versorgung'") }
+    it { expect(subject.segments[0].to_edifact).to eq("INV+versicherten_nr+18000+0+beleg_nr+besondere_versorgung'") }
     it { expect(subject.segments[1].to_edifact).to eq("URI+123456789+sammel:einzel+20200101+belegnum'") }
     it { expect(subject.segments[2].to_edifact).to eq("NAD+vers_nachname+vers_vorname+20101009+vers_strasse+vers_plz+vers_ort+vers_kennzeichen'") }
     it { expect(subject.segments[3].to_edifact).to eq("IMG+2010+10+merkmal'") }

--- a/spec/unit/edifact/message/slla/other_spec.rb
+++ b/spec/unit/edifact/message/slla/other_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe RubyGkvBilling::Edifact::Message::Slla::Other do
 
   it { expect(subject.bes_segment.to_edifact).to eq("BES+1234,00+765,00+45,00+7854,00+456,00'") }
 
-  it { expect(subject.inv_segment.to_edifact).to eq("INV+versicherten_nr+00018+0+beleg_nr+besondere_versorgung'") }
+  it { expect(subject.inv_segment.to_edifact).to eq("INV+versicherten_nr+18000+0+beleg_nr+besondere_versorgung'") }
 
   it { expect(subject.uri_segment.to_edifact).to eq("URI+123456789+sammel:einzel+20200101+belegnum'") }
 
@@ -112,7 +112,7 @@ RSpec.describe RubyGkvBilling::Edifact::Message::Slla::Other do
   it { expect(subject.segments.count).to eq(12) }
 
   describe "in sequence" do
-    it { expect(subject.segments[0].to_edifact).to eq("INV+versicherten_nr+00018+0+beleg_nr+besondere_versorgung'") }
+    it { expect(subject.segments[0].to_edifact).to eq("INV+versicherten_nr+18000+0+beleg_nr+besondere_versorgung'") }
     it { expect(subject.segments[1].to_edifact).to eq("URI+123456789+sammel:einzel+20200101+belegnum'") }
     it { expect(subject.segments[2].to_edifact).to eq("NAD+vers_nachname+vers_vorname+20101009+vers_strasse+vers_plz+vers_ort+vers_kennzeichen'") }
     it { expect(subject.segments[3].to_edifact).to eq("IMG+2010+01+merkmal'") }

--- a/spec/unit/edifact/message/slla_spec.rb
+++ b/spec/unit/edifact/message/slla_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe RubyGkvBilling::Edifact::Message::Slla do
     ["UNH+00123+SLLA:13:0:0'",
     "FKT+01++IK5430684+IK8234568+IK8643456+'",
     "REC+sammel_nummer:001+20101010+0'",
-    "INV+versicherten_nr+00018+0+beleg_nr+besondere_versorgung'",
+    "INV+versicherten_nr+18000+0+beleg_nr+besondere_versorgung'",
     "NAD+vers_nachname+vers_vorname+20101009+vers_strasse+vers_plz+vers_ort+vers_kennzeichen'",
     "IMG+2010+10+merkmal'",
     "UNT+000007+00123'"].join("\n")


### PR DESCRIPTION
Moin :) 

Erstmal vielen Dank für dieses gem!

Mir fiel ein Fehler im Versichertenstatus des INV-Segments auf. 

> alle lesbaren Zeichen werden nacheinander in das Feld geschrieben und ggfs. auf 5 Stellen rechtsbündig mit Nullen ergänzt, z.B. 10000 oder 18000

(Seite 44: https://gkv-datenaustausch.de/media/dokumente/leistungserbringer_1/sonstige_leistungserbringer/technische_anlagen_aktuell_4/Anlage_1_TP5_V14_20200908.pdf)

Nach kurzem Check im TA-Validator von DAVASO (https://portal.davaso.de/tavalidator/secure/validation), scheint die bisher verwendete Reihenfolge falsch zu sein. 

Sagt mir gern Bescheid wenn ich etwas vergessen haben sollte oder ich irgendwelche Guidelines nicht beachtet habe. Dann kann ich es ggf. im nächsten PR beachten. 